### PR TITLE
able to set the bedrock's aws region in cdk.json

### DIFF
--- a/deployment/cdk.json
+++ b/deployment/cdk.json
@@ -59,7 +59,8 @@
     "model_type":"other",
     "enable_content_moderation": false,
     "content_moderation_api_cn": "https://gtf.ai.xingzheai.cn/v2.0/game_chat_ban/detect_text",
-    "content_moderation_api": "https://gtf.ai.xingzheai.cn/v2.0/game_chat_ban/detect_text"
+    "content_moderation_api": "https://gtf.ai.xingzheai.cn/v2.0/game_chat_ban/detect_text",
+    "bedrock_aws_region": ""
   }
 }
 

--- a/deployment/lib/ss_lambdastack.py
+++ b/deployment/lib/ss_lambdastack.py
@@ -259,6 +259,8 @@ class LambdaStack(Stack):
         search_engine_zilliz = self.node.try_get_context("search_engine_zilliz")
         zilliz_endpoint = self.node.try_get_context("zilliz_endpoint")
         zilliz_token = self.node.try_get_context("zilliz_token")
+        bedrock_aws_region = self.node.try_get_context('bedrock_aws_region')
+
         # configure the lambda role
         if search_engine_kendra:
             _langchain_processor_role_policy = _iam.PolicyStatement(
@@ -338,6 +340,8 @@ class LambdaStack(Stack):
         langchain_processor_qa_function.add_environment("search_engine_zilliz", str(search_engine_zilliz))
         langchain_processor_qa_function.add_environment("zilliz_endpoint", str(zilliz_endpoint))
         langchain_processor_qa_function.add_environment("zilliz_token", str(zilliz_token))
+        if bedrock_aws_region:
+            langchain_processor_qa_function.add_environment("bedrock_aws_region", str(bedrock_aws_region))
 
         #publish a new version
         version = _lambda.Version(

--- a/lambda/langchain_processor_qa/model.py
+++ b/lambda/langchain_processor_qa/model.py
@@ -17,11 +17,17 @@ from langchain.schema.messages import BaseMessage
 from typing import Any, Callable, Dict, List, Optional, Tuple, Type, Union 
 from langchain.callbacks.manager import CallbackManagerForChainRun
 import inspect 
-
+import os
 import time
 time_seq=1
 last_time=time.time()
 init_time=last_time
+
+# Get Bedrock's AWS region, default to lambda's deployment region
+region = os.environ.get('AWS_REGION')
+bedrock_region = os.environ.get('bedrock_aws_region', region)
+
+
 def printTime(title):
     global time_seq
     global last_time
@@ -250,13 +256,15 @@ def init_model_llama2(endpoint_name,region_name,temperature):
 
 def init_model_bedrock(model_id):
     try:
-        llm = Bedrock(model_id=model_id)
+        llm = Bedrock(model_id=model_id, region_name=bedrock_region)
         return llm
     except Exception as e:
         return None
+
 def init_model_bedrock_withstreaming(model_id,callbackHandler):
     try:
         llm = Bedrock(model_id=model_id,
+                      region_name=bedrock_region,
                       streaming=True,
                      callbacks=[callbackHandler],)
         return llm


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
add bedrock_aws_region config in cdk.json. The available values are us-east-1, us-west-2 etc.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
